### PR TITLE
stack allocate dictionary

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -13,7 +13,7 @@ func compress(in []byte) (out []byte, sz int) {
 	var m_off int
 	in_len := len(in)
 	ip_len := in_len - m2_MAX_LEN - 5
-	dict := make([]int32, 1<<d_BITS)
+	var dict [1 << d_BITS]int32
 	ii := 0
 	ip := 4
 	for {

--- a/compress_test.go
+++ b/compress_test.go
@@ -184,6 +184,17 @@ func BenchmarkComp(b *testing.B) {
 	}
 }
 
+func BenchmarkComp2(b *testing.B) {
+	var testString = []byte("The quick brown fox jumps over the lazy dog")
+	b.ResetTimer()
+	b.ReportAllocs()
+	var sink []byte
+	for i := 0; i < b.N; i++ {
+		sink = Compress1X(testString)
+	}
+	_ = sink
+}
+
 func BenchmarkDecomp(b *testing.B) {
 	f, err := os.Open("testdata/large.tar.gz")
 	if err != nil {


### PR DESCRIPTION
BEFORE
```
goos: darwin
goarch: amd64
pkg: github.com/GetStream/go-lzo
BenchmarkComp2
BenchmarkComp2-8   	  129528	      7943 ns/op	   65592 B/op	       3 allocs/op
PASS
```

AFTER
```
goos: darwin
goarch: amd64
pkg: github.com/GetStream/go-lzo
BenchmarkComp2
BenchmarkComp2-8   	  579325	      2216 ns/op	      56 B/op	       2 allocs/op
PASS
```